### PR TITLE
[PKG-2105] sudachidict-core 20230110

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,8 @@ source:
   sha256: 35e3fa212e797d23c2147816febb6a5b870c4fe81fa05ad94ece271f23ea4656
 
 build:
-  script: {{ PYTHON }} -m pip install . -vv
   number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
@@ -26,15 +26,19 @@ requirements:
 test:
   imports:
     - sudachidict_core
-  commands:
-    - pip check
   requires:
     - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/WorksApplications/SudachiDict
+  dev_url: https://github.com/WorksApplications/SudachiDict
+  doc_url: https://github.com/WorksApplications/SudachiDict
   summary: Sudachi Dictionary for SudachiPy - Core Edition
+  description: Sudachi Dictionary for SudachiPy - Core Edition
   license: Apache-2.0
+  license_family: Apache
   license_file:
     - LICENSE-2.0.txt
     - sudachidict_core/resources/LICENSE-2.0.txt


### PR DESCRIPTION
License: https://github.com/WorksApplications/SudachiDict/blob/develop/LICENSE-2.0.txt
Requirements: https://github.com/WorksApplications/SudachiDict/blob/develop/python/setup.py

Actions:
1. Add flags `--no-deps --no-build-isolation` to `script`
2. Add dev & doc urls
3. Add `description`
4. Add `license_family`

Notes:
- to enable **Japanese language** support in `spacy data models` https://github.com/AnacondaRecipes/spacy-models-feedstock/pull/1 we need to add:
  -  `supachipy 0.6.7` https://github.com/AnacondaRecipes/sudachipy-feedstock/pull/1 and 
  - `sudachidict-core 20230110` https://github.com/AnacondaRecipes/sudachidict-core-feedstock/pull/1. 
  - This is not obvious at first glance, because it is only clear when you generate the spacy data models' `meta.yaml` file by this script https://github.com/AnacondaRecipes/spacy-models-feedstock/blob/main/recipe/_update_spacy_recipe.py removing `"ja_core*"` from `SKIP_PATTERNS` https://github.com/AnacondaRecipes/spacy-models-feedstock/blob/a354664bc150819e5d45bb51d99e5f5e26a88aa2/recipe/_update_spacy_recipe.py#L17