### PR TITLE
sudachidict-core 20260428 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "sudachidict-core" %}
-{% set version = "20250825" %}
+{% set version = "20260428" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0]|upper }}/SudachiDict-core/{{ name.replace( '-', '_' )}}-{{ version }}.tar.gz
-  sha256: 2f987c06c225c9fbeb7324705ff86ba635c8e9cf1ae5d4994e5df8f14aed78c6
+  sha256: 5492112a4a0999116cb8e4327b5ad3263167e9451fc8b50e8e7b83fc00bd2d98
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,11 +2,11 @@
 {% set version = "20260428" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0]|upper }}/SudachiDict-core/{{ name.replace( '-', '_' )}}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace( '-', '_' )}}-{{ version }}.tar.gz
   sha256: 5492112a4a0999116cb8e4327b5ad3263167e9451fc8b50e8e7b83fc00bd2d98
 
 build:


### PR DESCRIPTION
sudachidict-core 20260428 

**Destination channel:** Defaults

### Links

- [PKG-15731]
- dev_url:        https://github.com/WorksApplications/SudachiDict/tree/v20260428
- conda_forge:    https://github.com/conda-forge/sudachidict-core-feedstock
- pypi:           https://pypi.org/project/sudachidict-core/20260428
- pypi inspector: https://inspector.pypi.io/project/sudachidict-core/20260428

### Explanation of changes:

- new version number


[PKG-15731]: https://anaconda.atlassian.net/browse/PKG-15731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ